### PR TITLE
move roave/security-advisories to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     }
   ],
   "require": {
-    "php": "^7.2 || ^8.0",
-    "roave/security-advisories": "dev-master"
+    "php": "^7.2 || ^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0 || ^9.0",
     "prooph/php-cs-fixer-config": "^0.4",
     "php-coveralls/php-coveralls": "^2.0",
-    "malukenho/docheader": "^0.1.4"
+    "malukenho/docheader": "^0.1.4",
+    "roave/security-advisories": "dev-latest"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Hi,

As roave/security-advisories README, it should be included in require-dev. Also, the tag has changed from "dev-master" to "dev-latest"

